### PR TITLE
Add process Idle status

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -26,11 +26,12 @@ var (
 	ProcessZombie        = "Z"
 	ProcessTracedStopped = "T"
 	ProcessPaging        = "W"
+	ProcessIdle          = "I"
 )
 
-// Error Tyep
+// Error Type
 var (
-	ProcessNotFound error = errors.New("process : process not founded")
+	ProcessNotFound error = errors.New("process : process not found")
 )
 
 // Process Signal
@@ -79,6 +80,8 @@ func NewProcess(id int) (p Process, err error) {
 		p.State = ProcessTracedStopped
 	case ProcessPaging:
 		p.State = ProcessPaging
+	case ProcessIdle:
+		p.State = ProcessIdle
 	}
 
 	// process group id


### PR DESCRIPTION
Currently, I is also a valid status for a process as shown in the following example. This patch adds the Idle status to the list of valid status.

me@labo:/proc$ cat /proc/75/stat
75 (nvme-reset-wq) I 2 0 0 0 -1 69238880 0 0 0 0 0 0 0 0 0 -20 1 0 \ 133 0 0 4294967295 0 0 0 0 0 0 0 2147483647 0 0 0 0 17 2 0 0 0 0 0 \ 0 0 0 0 0 0 0 0
me@labo:/proc$ cat /proc/75/status
Name:   nvme-reset-wq
Umask:  0000
State:  I (idle)
Tgid:   75
*snip*