### PR TITLE
Fix error when splitting stat string only by space

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -11,11 +11,11 @@ import (
 )
 
 type Process struct {
-	Pid   int
-	PPid  int
-	Cmd   string
-	State string
-	Pgrp  int
+	Pid   int    // process id
+	PPid  int    // parent process id
+	Pgrp  int    // process group id
+	Cmd   string // process command
+	State string // process state
 }
 
 // Process state
@@ -42,9 +42,6 @@ const (
 func NewProcess(id int) (Process, error) {
 	var (
 		p        Process
-		pid      int
-		ppid     int
-		pgrp     int
 		statByte []byte
 		encap    bool
 		err      error
@@ -65,16 +62,14 @@ func NewProcess(id int) (Process, error) {
 	})
 
 	// pid init
-	if pid, err = strconv.Atoi(stat[0]); err != nil {
-		return Process{}, err
+	if p.Pid, err = strconv.Atoi(stat[0]); err != nil {
+		return Process{}, fmt.Errorf("NewProcess::p.Pid: %w", err)
 	}
-	p.Pid = pid
 
 	// ppid init
-	if ppid, err = strconv.Atoi(stat[3]); err != nil {
-		return Process{}, err
+	if p.PPid, err = strconv.Atoi(stat[3]); err != nil {
+		return Process{}, fmt.Errorf("NewProcess::p.PPid: %w", err)
 	}
-	p.PPid = ppid
 
 	p.Cmd = strings.TrimRight(strings.TrimLeft(stat[1], "("), ")")
 
@@ -96,10 +91,9 @@ func NewProcess(id int) (Process, error) {
 	}
 
 	// process group id
-	if pgrp, err = strconv.Atoi(stat[4]); err != nil {
-		return Process{}, err
+	if p.Pgrp, err = strconv.Atoi(stat[4]); err != nil {
+		return Process{}, fmt.Errorf("NewProcess::p.Pgrp: %w", err)
 	}
-	p.Pgrp = pgrp
 
 	return p, nil
 }

--- a/process/process.go
+++ b/process/process.go
@@ -39,25 +39,39 @@ const (
 )
 
 // convert pid to process object
-func NewProcess(id int) (p Process, err error) {
-	// read process status
+func NewProcess(id int) (Process, error) {
+	var (
+		p        Process
+		pid      int
+		ppid     int
+		pgrp     int
+		statByte []byte
+		encap    bool
+		err      error
+	)
 
-	statByte, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/stat", id))
+	// read process status
+	statByte, err = ioutil.ReadFile(fmt.Sprintf("/proc/%d/stat", id))
 	if err != nil {
 		return Process{}, ProcessNotFound
 	}
-	stat := strings.Split(string(statByte), " ")
+
+	// split stat to fields. We split by space, but not when it's encapsulated by '(' and ')'
+	stat := strings.FieldsFunc(string(statByte), func(r rune) bool {
+		if r == '(' || r == ')' {
+			encap = !encap
+		}
+		return !encap && r == ' '
+	})
 
 	// pid init
-	pid, err := strconv.Atoi(stat[0])
-	if err != nil {
+	if pid, err = strconv.Atoi(stat[0]); err != nil {
 		return Process{}, err
 	}
 	p.Pid = pid
 
 	// ppid init
-	ppid, err := strconv.Atoi(stat[3])
-	if err != nil {
+	if ppid, err = strconv.Atoi(stat[3]); err != nil {
 		return Process{}, err
 	}
 	p.PPid = ppid
@@ -82,13 +96,12 @@ func NewProcess(id int) (p Process, err error) {
 	}
 
 	// process group id
-	pgrp, err := strconv.Atoi(stat[4])
-	if err != nil {
+	if pgrp, err = strconv.Atoi(stat[4]); err != nil {
 		return Process{}, err
 	}
 	p.Pgrp = pgrp
 
-	return
+	return p, nil
 }
 
 // process Kill


### PR DESCRIPTION
observe:
me@labo:/proc$ cat /proc/79/stat
79 (DWC Notificatio) I 2 0 0 0 -1 69238880 0 0 0 0 0 0 0 0 0 -20 1 0 \ 156 0 0 4294967295 0 0 0 0 0 0 0 2147483647 0 0 0 0 17 2 0 0 0 0 0 0 \ 0 0 0 0 0 0 0

When splitting simply by space, the 2nd field is "DWC" and the 3rd is "Notificatio".  This is not what we want. We want the 3rd field to be an integer for the parent process ID. Otherwise the strconv.Atoi(stat[3]) fails with a parse error on I. Hence we need an exception on the splits if the space is encapsulated by parentheses.